### PR TITLE
feat: integrate refresh token authentication with login and refresh endpoints

### DIFF
--- a/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/controller/AuthController.java
+++ b/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/controller/AuthController.java
@@ -1,36 +1,61 @@
 package com.springwiththeo.week8.db_jwt_authentication.controller;
 
+import com.springwiththeo.week8.db_jwt_authentication.dto.RefreshRequest;
+import com.springwiththeo.week8.db_jwt_authentication.dto.TokenResponse;
+import com.springwiththeo.week8.db_jwt_authentication.repository.RefreshToken;
+import com.springwiththeo.week8.db_jwt_authentication.repository.User;
 import com.springwiththeo.week8.db_jwt_authentication.service.JwtService;
+import com.springwiththeo.week8.db_jwt_authentication.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
-
-    public AuthController(AuthenticationManager authenticationManager, JwtService jwtService) {
-        this.authenticationManager = authenticationManager;
-        this.jwtService = jwtService;
-    }
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/login")
-    public String login(@RequestParam String username,@RequestParam String password) {
+    public ResponseEntity<TokenResponse> login(@RequestParam String username,@RequestParam String password) {
         // Authenticate the user
         Authentication authenticate = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(username, password)
         );
 
         // Generate JWT token
-        return "Add this token in Bearer header to authenticate with Jwt: "+jwtService.generateToken(authenticate.getName(), authenticate.getAuthorities());
+        String jwtToken = jwtService.generateToken(authenticate.getName(), authenticate.getAuthorities());
+        RefreshToken refreshToken = refreshTokenService.createRefreshToken(authenticate.getName());
+        TokenResponse body = new TokenResponse(jwtToken, refreshToken.getToken(), "Bearer", 15);
+        return ResponseEntity.ok(body);
 
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody RefreshRequest refreshTokenRequest) {
+        RefreshToken validRefreshToken = refreshTokenService.verifyRefreshToken(refreshTokenRequest.refreshToken());
+
+        User user = validRefreshToken.getUser();
+        var authorities = user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
+
+        //create a new JWT token (stateless)
+        String newToken = jwtService.generateToken(user.getUsername(), authorities);
+
+        //rotate the refresh token (stateful)
+        RefreshToken newRefreshToken = refreshTokenService.tokenRotation(validRefreshToken);
+
+        TokenResponse body = new TokenResponse(newToken, newRefreshToken.getToken(), "Bearer",30);
+
+        return ResponseEntity.ok(body);
+
+    }
 
 }

--- a/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/dto/RefreshRequest.java
+++ b/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/dto/RefreshRequest.java
@@ -1,0 +1,4 @@
+package com.springwiththeo.week8.db_jwt_authentication.dto;
+
+public record RefreshRequest(String refreshToken) {
+}

--- a/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/dto/TokenResponse.java
+++ b/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/dto/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.springwiththeo.week8.db_jwt_authentication.dto;
+
+public record TokenResponse(String accessToken, String refreshToken, String tokenType, long expiresInSeconds) {
+    // This record will automatically generate a constructor, getters, and equals/hashCode methods
+    // for the accessToken and refreshToken fields.
+}

--- a/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/service/JwtService.java
+++ b/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/service/JwtService.java
@@ -11,14 +11,14 @@ import org.springframework.stereotype.Service;
 import java.security.Key;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 public class JwtService {
     private final Key key= Keys.secretKeyFor(SignatureAlgorithm.HS256);
-    private final long accessTokenExpirationTimeMs =  1000*60*15; // 15 minutes
+    private final long accessTokenExpirationTimeMs =  1000*15; // 15 seconds
 
     public String generateToken(String username) {
         return Jwts.builder()
@@ -31,8 +31,8 @@ public class JwtService {
 
     public String generateToken(String username, Collection<? extends GrantedAuthority> authorities) {
         return Jwts.builder()
-                .setSubject(username)
                 .setClaims(Map.of("roles",authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet())))
+                .setSubject(username)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationTimeMs))
                 .signWith(key)
@@ -43,8 +43,8 @@ public class JwtService {
         return extractAllClaims(token).getSubject();
     }
 
-    public Set<String> extractRoles(String token) {
-        return extractAllClaims(token).get("roles", Set.class);
+    public List<String> extractRoles(String token) {
+        return extractAllClaims(token).get("roles", List.class);
     }
 
     private Claims extractAllClaims(String token) {

--- a/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/service/RefreshTokenService.java
+++ b/Week 9-db-jwt-authentication/db-jwt-authentication/src/main/java/com/springwiththeo/week8/db_jwt_authentication/service/RefreshTokenService.java
@@ -3,6 +3,7 @@ package com.springwiththeo.week8.db_jwt_authentication.service;
 import com.springwiththeo.week8.db_jwt_authentication.repository.RefreshToken;
 import com.springwiththeo.week8.db_jwt_authentication.repository.RefreshTokenRepository;
 import com.springwiththeo.week8.db_jwt_authentication.repository.User;
+import com.springwiththeo.week8.db_jwt_authentication.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +15,7 @@ import java.util.Base64;
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
-
+    private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
     private final Duration refreshTokenValidity = Duration.ofDays(30);
@@ -36,6 +37,17 @@ public class RefreshTokenService {
     }
 
     private RefreshToken createRefreshToken(User user) {
+        String token = generateOpaqueToken();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(token);
+        refreshToken.setUser(user);
+        refreshToken.setExpiryAt(Instant.now().plus(refreshTokenValidity));
+        return refreshTokenRepository.save(refreshToken);
+    }
+    public RefreshToken createRefreshToken(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + username));
+
         String token = generateOpaqueToken();
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setToken(token);


### PR DESCRIPTION
## Description
What does this PR do? (Summarize the changes)
Updated AuthController by return the accessToken  + RefreshToken.
Users can now get a new accessToken that lasts 15 secs without logging in with username and password.
---

## Issue Reference
Fixes #22

---

## Changes Made


---

## How to Test
1. 
2. 
3. 

---

## Checklist
- [ ] Code compiles without errors
- [ ] Tests (manual or automated) were run
- [ ] Linked this PR to the relevant issue
- [ ] Updated documentation/README if needed

---

## Screenshots (if applicable)
