### PR TITLE
feat: implement CustomUserDetails class for user authentication

### DIFF
--- a/Week 10-Method-security/method-security/src/main/java/com/springwiththeo/week10/method_security/model/CustomUserDetails.java
+++ b/Week 10-Method-security/method-security/src/main/java/com/springwiththeo/week10/method_security/model/CustomUserDetails.java
@@ -1,0 +1,49 @@
+package com.springwiththeo.week10.method_security.model;
+
+import com.springwiththeo.week10.method_security.repository.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+   private final Long id;
+   private final String username;
+   private final String password;
+   private final Set<GrantedAuthority> authorities;
+
+   public CustomUserDetails(User user) {
+      this.id= user.getId();
+        this.username = user.getUsername();
+        this.password = user.getPassword();
+        authorities=user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
+    }
+
+
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/Week 10-Method-security/method-security/src/main/java/com/springwiththeo/week10/method_security/service/CustomerUserDetailsService.java
+++ b/Week 10-Method-security/method-security/src/main/java/com/springwiththeo/week10/method_security/service/CustomerUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.springwiththeo.week10.method_security.service;
 
 
+import com.springwiththeo.week10.method_security.model.CustomUserDetails;
 import com.springwiththeo.week10.method_security.repository.User;
 import com.springwiththeo.week10.method_security.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +21,6 @@ public class CustomerUserDetailsService implements UserDetailsService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
 
-        return org.springframework.security.core.userdetails.User
-                .withUsername(username)
-                .password(user.getPassword())
-                .authorities(user.getRoles().toArray(new String[0]))
-                .build();
+        return new CustomUserDetails(user);
     }
 }


### PR DESCRIPTION
## Description
Created a CustomUserDetails class adding more identifying info about the authenticated user.
Now we can check for the id, adding it to the token and queryable in the spel query.
Accessible in SpEL as authentication.principal.id.


---

## Issue Reference
Fixes #31

---

## Changes Made
- Created custom implementation of `UserDetails`, the object return to the `AuthenticationManager` at login by `CustomrUserDetailsService`, with an added **id** field.
- `CustomUserDetailsService.java` returns the `CustomUserDetails object`, rather than basic `UserDetails` object.

---

## How to Test
1. 
2. 
3. 

---

## Checklist
- [x] Code compiles without errors
- [x] Tests (manual or automated) were run
- [x] Linked this PR to the relevant issue
- [x] Updated documentation/README if needed

---

## Screenshots (if applicable)
