### PR TITLE
add token generation method to JwtService that adds the user id in the token

### DIFF
--- a/Week 10-Method-security/method-security/src/main/java/com/springwiththeo/week10/method_security/service/JwtService.java
+++ b/Week 10-Method-security/method-security/src/main/java/com/springwiththeo/week10/method_security/service/JwtService.java
@@ -39,6 +39,16 @@ public class JwtService {
                 .compact();
     }
 
+    public String generateToken(long userId, String username, Collection<? extends GrantedAuthority> authorities) {
+        return Jwts.builder()
+                .setClaims(Map.of("roles",authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet())))
+                .setSubject(username)
+                .claim("id", userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationTimeMs))
+                .signWith(key)
+                .compact();
+    }
     public String extractUsername(String token) {
         return extractAllClaims(token).getSubject();
     }


### PR DESCRIPTION
## Description
What does this PR do? (Summarize the changes)
add token generation method to JwtService that adds the user id in the token
---

## Issue Reference
Fixes #33 

---

## Changes Made
- Overloads the generateToken() including an id claim and method to extract it

---

## How to Test
1. 
2. 
3. 

---

## Checklist
- [ ] Code compiles without errors
- [ ] Tests (manual or automated) were run
- [ ] Linked this PR to the relevant issue
- [ ] Updated documentation/README if needed

---

## Screenshots (if applicable)
