### PR TITLE
Create Book entity and repository; configure application properties f…

### DIFF
--- a/Week 13-Data-Access/src/main/java/com/springwiththeo/week13/data_access/SpringDataAccessProjectApplication.java
+++ b/Week 13-Data-Access/src/main/java/com/springwiththeo/week13/data_access/SpringDataAccessProjectApplication.java
@@ -1,7 +1,11 @@
 package com.springwiththeo.week13.data_access;
 
+import com.springwiththeo.week13.data_access.model.Book;
+import com.springwiththeo.week13.data_access.repo.BookRepository;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class SpringDataAccessProjectApplication {
@@ -10,4 +14,13 @@ public class SpringDataAccessProjectApplication {
 		SpringApplication.run(SpringDataAccessProjectApplication.class, args);
 	}
 
+    @Bean
+    CommandLineRunner init(BookRepository bookRepository) {
+        return args -> {
+            // Initialize the database with some books if needed
+            bookRepository.save(new Book("1984", "George Orwell"));
+            bookRepository.save(new Book("To Kill a Mockingbird", "Harper Lee"));
+            bookRepository.findAll().forEach(book->System.out.print(book.getTitle()+" by "+book.getAuthor()+"\n"));
+        };
+    }
 }

--- a/Week 13-Data-Access/src/main/java/com/springwiththeo/week13/data_access/model/Book.java
+++ b/Week 13-Data-Access/src/main/java/com/springwiththeo/week13/data_access/model/Book.java
@@ -1,0 +1,27 @@
+package com.springwiththeo.week13.data_access.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class Book {
+
+    @Getter(onMethod_ = {@Id,@GeneratedValue(strategy = GenerationType.IDENTITY)})
+    private Long id;
+    private String title;
+    private String author;
+
+    public Book(String title, String author) {
+        this.title = title;
+        this.author = author;
+    }
+
+    // Constructors, getters, and setters
+}

--- a/Week 13-Data-Access/src/main/java/com/springwiththeo/week13/data_access/repo/BookRepository.java
+++ b/Week 13-Data-Access/src/main/java/com/springwiththeo/week13/data_access/repo/BookRepository.java
@@ -1,0 +1,9 @@
+package com.springwiththeo.week13.data_access.repo;
+
+import com.springwiththeo.week13.data_access.model.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/Week 13-Data-Access/src/main/resources/application.properties
+++ b/Week 13-Data-Access/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Spring Data Access Project

--- a/Week 13-Data-Access/src/main/resources/application.yml
+++ b/Week 13-Data-Access/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: Spring Data Access Project
+
+
+  datasource:
+    url: jdbc:h2:mem:week13db
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    hibernate:
+      ddl-auto: update   # auto-create tables from entities
+    show-sql: true        # log SQL to console
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
…or H2 database

Closes #40

## Description
What does this PR do? (Summarize the changes)
Mapping Java classes to DB tables, and repositories provide persistence without boilerplate SQL.
---

## Issue Reference
Fixes #40 

---

## Changes Made
- [x] 		Define a Book entity with fields: id, title, author.
- [x] Create BookRepository interface extending JpaRepository.
- [x] 		Configure H2 in-memory database.
- [x] 		Save & fetch books in a test runner.


---

## How to Test
1. 
2. 
3. 

---

## Checklist
- [ ] Code compiles without errors
- [ ] Tests (manual or automated) were run
- [ ] Linked this PR to the relevant issue
- [ ] Updated documentation/README if needed

---

## Screenshots (if applicable)
